### PR TITLE
set up javadoc extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
 *.iml
 .idea
+.cache
+node_modules
 local-antora-playbook.yml

--- a/dj-local-antora-playbook.yml
+++ b/dj-local-antora-playbook.yml
@@ -5,8 +5,8 @@ site:
 content:
   sources:
 #    - url: https://github.com/MorphiaOrg/morphia-docs-new
-# since you haven't merged the pr yet....
-    - url: https://github.com/djencks/morphia-docs-new.git
+#    - url: https://github.com/djencks/morphia-docs-new.git
+    - url: ./../morphia-docs-new
       branches: javadoc
       start_path: docs
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "description": "Morphia docs",
   "scripts": {
     "clean-build": "npm run clean-install;npm run build",
+    "clean-local-build": "npm run clean-install;npm run local-build",
     "clean-install": "rm -rf node_modules/ .cache/ package-lock.json ;npm i --cache=.cache/npm",
     "build": "antora --generator @djencks/site-generator-default antora-playbook.yml --stacktrace --fetch",
     "local-build": "antora --generator @djencks/site-generator-default local-antora-playbook.yml --stacktrace --fetch"


### PR DESCRIPTION
set up javadoc extension, extend .gitignore, provide working local playbook.

- Playbook points to my fork since that's where the working remote branch is.  If you merge the pr, of course the playbook should point to the real repo.

- I provided a working local playbook, assuming this project and the docs project are cloned next to one another.
